### PR TITLE
Allow bg images when using visually-hidden mixin

### DIFF
--- a/assets/scss/govuk/_@mixins.scss
+++ b/assets/scss/govuk/_@mixins.scss
@@ -29,8 +29,7 @@
 @mixin visually-hidden {
   clip: rect(0 0 0 0);
   overflow: hidden;
-  position: absolute;
-  opacity: 0;
+  position: static;
   padding: 0;
   margin: 0;
   width: 1px;


### PR DESCRIPTION
Without this the OGL logo in the footer is not visible.
