### PR TITLE
Remove unnecessary padding around subheader

### DIFF
--- a/assets/scss/govuk/elements/_global-subheader.scss
+++ b/assets/scss/govuk/elements/_global-subheader.scss
@@ -2,6 +2,7 @@
 
 .global-header + .global-subheader {
   padding: $container-v-padding $container-h-padding;
+  background-color: $white;
 }
 
 .subheader-item {


### PR DESCRIPTION
Currently applied when a sibling of #global-header
